### PR TITLE
Make second parameter optional as we can already define it in crontab

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,10 @@ Using this is rather simple, the script "run-if-today" evaluates its parameters 
 If run-if-today returns 1 (false in Bash) then the && (and) will stop the operation and nothing happens.
 
 You could use a * instead of 6 for the day of week, the script checks if it's Saturday and within the date range of the desired week, but in order to execute this code as little as possible it's recommended to fix a weekday so it runs at most 4 or 5 times a month.
+
+Or you could possibly completely omit the second parameter and inherit it from cron since we are already specifying parameter. For example:
+
+
+    30 6 * * 6 root run-if-today 1 && /root/myfirstsaturdaybackup.sh
+
+is equivalent to previous cronjob.

--- a/run-if-today
+++ b/run-if-today
@@ -32,9 +32,9 @@ MONTH=${ARRAY[1]}
 TODAY=${ARRAY[2]}
 WEEK_DAY=${ARRAY[3]}
 
-# If is not that day of the week don't even bother running all the
+# If the day is provided but it is not that day of the week, don't even bother running all the
 # cool checks.
-if [ $WEEK_DAY != ${2:0:3} ]
+if [ ! -z "$2" ] && [ $WEEK_DAY != ${2:0:3} ]
 then
 	exit 1
 fi


### PR DESCRIPTION
Great script, simplistic and powerful.
I tend to minimize error surface, and specifying day of the week only once makes sense.
But of course, option can remain for others.